### PR TITLE
refactor: 로그인 페이지에서 로그인 실패 시 에러메세지 보여주는 기능 추가 구현

### DIFF
--- a/src/main/java/com/example/demo/member/controller/LoginController.java
+++ b/src/main/java/com/example/demo/member/controller/LoginController.java
@@ -1,19 +1,22 @@
 package com.example.demo.member.controller;
 
-import com.example.demo.security.jwt.JwtTokenProvider;
-import com.example.demo.security.mapper.UserMapper;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class LoginController {
 
-
+//    @GetMapping("/login")
+//    public String login(){
+//        return "loginPage";
+//    }
 
     @GetMapping("/login")
-    public String login(){
+    public String login(String error, Model model){
+        System.out.println("error: " + error);
+        model.addAttribute("errorMessage", error);
+
         return "loginPage";
     }
 

--- a/src/main/resources/templates/loginPage.html
+++ b/src/main/resources/templates/loginPage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
@@ -20,6 +20,7 @@
         <p><input type="checkbox" name="remember-me"> Remember me on this computer.</p>
         <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
     </form>
+    <div th:text="${errorMessage}">기본 메시지</div> <br/>
     <a href="/oauth2/authorization/google">Google Login</a>
 </div>
 


### PR DESCRIPTION
## resolve #issue number
#50 

## What is this PR? :mag:
사용자가 로그인 실패 시, 메세지를 보여줌으로써 어떤 부분으로 인해서 로그인을 실패했음을 알 수 있게 한다.

## Changes :memo:
- loginPage.html 을 staic -> thymeleaf 로 변경
- WebSecurityConfig.java 에서 로그인 실패 시, 예외처리를 세분화 구현

## Screenshot :camera:
![image](https://user-images.githubusercontent.com/54669100/178135047-fb801cdb-6e75-41fb-92d3-94193449eefe.png)

Close #{이슈_번호}
#50 
